### PR TITLE
arch-mvi-21 Fix get executing side effects (remove self) + small toSt…

### DIFF
--- a/mvi-sideeffect-solo/src/main/kotlin/dev/sunnyday/arch/mvi/side_effect/solo/ExecutingSideEffect.kt
+++ b/mvi-sideeffect-solo/src/main/kotlin/dev/sunnyday/arch/mvi/side_effect/solo/ExecutingSideEffect.kt
@@ -15,7 +15,12 @@ interface ExecutingSideEffect<out SideEffect : Any> : Cancellable {
         object Undefined : Id
 
         @Suppress("CanSealedSubClassBeObject")
-        class Unique : Id
+        class Unique : Id {
+
+            override fun toString(): String {
+                return "Id.Unique@${super.toString().substringAfterLast('@')}"
+            }
+        }
 
         data class Custom(val id: Any) : Id {
 

--- a/mvi-sideeffect-solo/src/test/kotlin/dev/sunnyday/arch/mvi/side_effect/solo/ExecutingSideEffectTest.kt
+++ b/mvi-sideeffect-solo/src/test/kotlin/dev/sunnyday/arch/mvi/side_effect/solo/ExecutingSideEffectTest.kt
@@ -1,0 +1,16 @@
+package dev.sunnyday.arch.mvi.side_effect.solo
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class ExecutingSideEffectTest {
+
+    @Test
+    fun `UniqueId toString() prints short name`() {
+        println(ExecutingSideEffect.Id.Unique().toString())
+        assertTrue(
+            ExecutingSideEffect.Id.Unique().toString()
+                .startsWith("Id.Unique@")
+        )
+    }
+}


### PR DESCRIPTION
Fixed skipIfAlreadyExecuting(sideEffectsWithSameType()).
Improved ExecutingSideEffect.Id.Unique.toString()